### PR TITLE
Allowing for custom field view in addField() to replace a custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ var field = new InputView({
     //  - an element with a `data-hook="main-message-container"` attribute (this we'll show/hide)
     //  - an elememt with a `data-hook="main-message-text"` attribute (where message text goes for error)
     template: // some HTML string,
-    // Template for individual view. It should be a string of HTML
-    // Make sure it has a single "root" element that contains
+    // InputView for individual view. Should ahere to the ampersand input view conventions
+    // Make sure it's template has a single "root" element that contains
     //  - an element with a `data-hook="label"` attribute
     //  - an element with a `data-hook="message-container"` attribute (this we'll show/hide)
     //  - an elememt with a `data-hook="message-text"` attribute (where message text goes for error)
-    fieldTemplate // HTML string
+    fieldView: // View class
     // Label name
     label: 'App Name',
     // Optional placeholder attribute

--- a/ampersand-array-input-view.js
+++ b/ampersand-array-input-view.js
@@ -11,16 +11,6 @@ var defaultTemplate = [
         '</div>',
     '</div>'
 ].join('');
-var defaultFieldTemplate = [
-    '<label>',
-        '<input>',
-        '<div data-hook="message-container" class="message message-below message-error">',
-            '<p data-hook="message-text"></p>',
-        '</div>',
-        '<a data-hook="remove-field">remove</a>',
-    '</label>'
-].join('');
-
 
 module.exports = View.extend({
     initialize: function () {
@@ -81,8 +71,8 @@ module.exports = View.extend({
         maxLength: ['number', true, 10],
         tests: ['array', true, function () { return []; }],
         template: ['string', true, defaultTemplate],
-        fieldTemplate: ['string', true, defaultFieldTemplate],
-        type: ['text', true, 'text']
+        type: ['text', true, 'text'],
+        fieldView: ['any', true, function() { return FieldView; }]
     },
     session: {
         shouldValidate: ['boolean', true, false],
@@ -161,8 +151,7 @@ module.exports = View.extend({
             removable: removable,
             type: this.type
         };
-        var field = new FieldView(initOptions);
-        field.template = this.fieldTemplate;
+        var field = new this.fieldView(initOptions);
         field.render();
         this.fieldsRendered += 1;
         this.fields.push(field);

--- a/lib/field-view.js
+++ b/lib/field-view.js
@@ -1,7 +1,18 @@
 var InputView = require('ampersand-input-view');
 var _ = require('underscore');
 
+var defaultFieldTemplate = [
+    '<label>',
+        '<input>',
+        '<div data-hook="message-container" class="message message-below message-error">',
+            '<p data-hook="message-text"></p>',
+        '</div>',
+        '<a data-hook="remove-field">remove</a>',
+    '</label>'
+].join('');
+
 module.exports = InputView.extend({
+    template: defaultFieldTemplate,
     bindings: _.extend({
         'removable': {
             type: 'toggle',
@@ -9,8 +20,7 @@ module.exports = InputView.extend({
         }
     }, InputView.prototype.bindings),
     props: {
-        removable: 'boolean',
-        template: ['string']
+        removable: 'boolean'
     },
     events: {
         'click [data-hook~=remove-field]': 'handleRemoveClick'


### PR DESCRIPTION
Instead of just allowing a custom field template, the array input view could potentially be used to render complex data structures via a custom field view. This update allows a custom view for each field if provided. By default, the base field view is used.

As a result, fieldViewTemplate can be removed and the defaultFieldViewTemplate string can be moved to the default FieldView allowing for better encapsulation.
