### PR TITLE
change how `removable` is determined.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright © 2014 &yet
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,4 @@
-The MIT License (MIT)
-
-Copyright © 2014 &yet
+Copyright © 2014 &yet, LLC and AmpersandJS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/ampersand-array-input-view.js
+++ b/ampersand-array-input-view.js
@@ -143,22 +143,12 @@ module.exports = View.extend({
         field.input.focus();
     },
     addField: function (value) {
-        var self = this;
-        var firstField = this.fields.length === 0;
-        var removable = function () {
-            if (firstField) return false;
-            if (self.fields.length >= (self.minLength || 1)) {
-                return true;
-            }
-            return false;
-        }();
         var initOptions = {
             value: value,
             parent: this,
             required: false,
             tests: this.tests,
             placeholder: this.placeholder,
-            removable: removable,
             type: this.type
         };
         var field = new FieldView(initOptions);
@@ -166,6 +156,7 @@ module.exports = View.extend({
         field.render();
         this.fieldsRendered += 1;
         this.fields.push(field);
+        this.setRemoveableFields();
         this.queryByHook('field-container').appendChild(field.el);
         return field;
     },
@@ -180,6 +171,7 @@ module.exports = View.extend({
         this.fields = _.without(this.fields, field);
         field.remove();
         this.fieldsRendered -= 1;
+        this.setRemoveableFields();
         this.update();
     },
     update: function () {
@@ -193,6 +185,11 @@ module.exports = View.extend({
             value: value,
             fieldsValid: valid
         });
+    },
+    setRemoveableFields: function() {
+	    this.fields.forEach(function(field, index, fields) {
+		    field.removable = (index > 0 || fields.length > 1);
+	    });
     },
     updateParent: function () {
         if (this.parent) this.parent.update(this);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-array-input-view",
   "description": "A view module for intelligently rendering and validating inputs that should produce an array of values. Works well with ampersand-form-view.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "bugs": {
     "url": "https://github.com/ampersandjs/ampersand-array-input-view/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-array-input-view",
   "description": "A view module for intelligently rendering and validating inputs that should produce an array of values. Works well with ampersand-form-view.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "bugs": {
     "url": "https://github.com/ampersandjs/ampersand-array-input-view/issues"


### PR DESCRIPTION
Addresses #8.

Not sure if this is the best way to do so, but it seems to work in practice, and passes all existing tests. Code line length is less, too.