### PR TITLE
Change removable behaviour

### DIFF
--- a/ampersand-array-input-view.js
+++ b/ampersand-array-input-view.js
@@ -146,22 +146,12 @@ module.exports = View.extend({
         field.input.focus();
     },
     addField: function (value) {
-        var self = this;
-        var firstField = this.fields.length === 0;
-        var removable = function () {
-            if (firstField) return false;
-            if (self.fields.length >= (self.minLength || 1)) {
-                return true;
-            }
-            return false;
-        }();
         var initOptions = {
             value: value,
             parent: this,
             required: false,
             tests: this.tests,
             placeholder: this.placeholder,
-            removable: removable,
             type: this.type
         };
         var field = new FieldView(initOptions);
@@ -169,6 +159,7 @@ module.exports = View.extend({
         field.render();
         this.fieldsRendered += 1;
         this.fields.push(field);
+        this._setRemoveableFields();
         this.queryByHook('field-container').appendChild(field.el);
         return field;
     },
@@ -183,7 +174,14 @@ module.exports = View.extend({
         this.fields = without(this.fields, field);
         field.remove();
         this.fieldsRendered -= 1;
+        this._setRemoveableFields();
         this.update();
+    },
+    _setRemoveableFields: function () {
+        var removable = this.fields.length > (this.minLength || 1);
+        this.fields.forEach(function(field) {
+            field.removable = removable;
+        });
     },
     update: function () {
         var valid = true;

--- a/ampersand-array-input-view.js
+++ b/ampersand-array-input-view.js
@@ -178,7 +178,7 @@ module.exports = View.extend({
         this.update();
     },
     _setRemoveableFields: function () {
-        var removable = this.fields.length > (this.minLength || 1);
+        var removable = this.fields.length > this.minLength;
         this.fields.forEach(function(field) {
             field.removable = removable;
         });

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,25 @@ test('clicking add/remove', function (t) {
     t.equal(input.el.querySelectorAll('input').length, 2, 'should have 2 fields');
     simClick(input.el.querySelectorAll('[data-hook=remove-field]')[1]);
     t.equal(input.el.querySelectorAll('input').length, 1, 'should have 1 fields');
+    document.body.removeChild(input.el);
+    t.end();
+});
+
+test('clicking remove with a minLength defined as 1', function (t) {
+     var input = new InputView({
+        name: 'hi',
+        minLength: 1
+    });
+    var addButton = input.el.querySelector('[data-hook=add-field]');
+    document.body.appendChild(input.el);
+    t.ok(addButton, 'make sure theres an add button');
+    t.equal(input.el.querySelectorAll('input').length, 1, 'should start with one');
+    t.ok(!isHidden(addButton));
+    simClick(addButton);
+    t.equal(input.el.querySelectorAll('input').length, 2, 'should be two after clicking add');
+    t.ok(!isHidden(addButton));
+    simClick(input.el.querySelectorAll('[data-hook=remove-field]')[1]);
+    t.equal(input.el.querySelectorAll('input').length, 1, 'should have 1 fields');
     t.ok(isHidden(input.el.querySelector('[data-hook=remove-field]')), 'should not have a remove button');
     document.body.removeChild(input.el);
     t.end();

--- a/test/index.js
+++ b/test/index.js
@@ -109,3 +109,34 @@ test('remove-field visibility', function (t) {
     document.body.removeChild(input.el);
     t.end();
 });
+
+test('remove-field visibility with minLength greater than 1', function (t) {
+    var input = new InputView({
+        name: 'hi',
+        maxLength: 3,
+        minLength: 2
+    });
+    document.body.appendChild(input.el);
+    var addButton = input.el.querySelector('[data-hook=add-field]');
+    
+    var i = 0;
+    for (i = 0; i < 2; i++) {
+	    t.ok(isHidden(input.el.querySelectorAll('[data-hook=remove-field]')[i]), 'field #' + i + '\'s remove button should be hidden to start');
+    }
+    
+    simClick(addButton);
+    
+    for (i = 0; i < 3; i++) {
+	    t.ok(!isHidden(input.el.querySelectorAll('[data-hook=remove-field]')[i]), 'field #' + i + '\'s remove button should be visible now');
+    }
+    
+    var removeButton = input.el.querySelector('[data-hook=remove-field]');
+    simClick(removeButton);
+    
+    for (i = 0; i < 2; i++) {
+        t.ok(isHidden(input.el.querySelectorAll('[data-hook=remove-field]')[i]), 'field #' + i + '\'s remove button should be hidden again');
+    }
+    
+    document.body.removeChild(input.el);
+    t.end();
+});


### PR DESCRIPTION
This allows any field to be removable*, including the first (current behaviour prohibits the first field to be removed), while preventing any field from being removed if doing so would not satisfy the `minLength` option.

This commit also adds test for this behaviour.

*”removable” meaning whether or not the remove button is shown.

Replaces #9 (the old PR was in a bad state, and the original branch was perma-deleted)
Closes #8